### PR TITLE
Switch release event to published

### DIFF
--- a/.github/workflows/archim.yml
+++ b/.github/workflows/archim.yml
@@ -17,7 +17,7 @@ on:
     - '**/*.md'
   release:
     types:
-      - created
+      - published
 
 jobs:
   build-platform-io:

--- a/.github/workflows/rambo.yml
+++ b/.github/workflows/rambo.yml
@@ -17,7 +17,7 @@ on:
     - '**/*.md'
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:

--- a/.github/workflows/ramps.yml
+++ b/.github/workflows/ramps.yml
@@ -17,7 +17,7 @@ on:
     - '**/*.md'
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:

--- a/.github/workflows/skr1p3.yml
+++ b/.github/workflows/skr1p3.yml
@@ -18,7 +18,7 @@ on:
     - '**/*.md'
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:

--- a/.github/workflows/skrpro.yml
+++ b/.github/workflows/skrpro.yml
@@ -18,7 +18,7 @@ on:
     - '**/*.md'
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
According to https://github.community/t/workflow-set-for-on-release-not-triggering-not-showing-up/16286/6
and testing done at https://forum.v1engineering.com/t/marlinbuild-again/19157/85

created is not triggered when a release is saved as draft before publishing.