### PR TITLE
Vary branch based on what event triggered the build

### DIFF
--- a/.github/workflows/archim.yml
+++ b/.github/workflows/archim.yml
@@ -32,9 +32,10 @@ jobs:
     strategy:
       fail-fast: false # Allow all machines to finish building
       matrix:
-        branch:
-        - 2.0.6
-        - bugfix-2.0.x
+        branch: ${{ fromJson(
+          github.event_name == 'schedule' && '["bugfix-2.0.x"]' ||
+          github.event_name == 'pull_request' && '["bugfix-2.0.x", "2.0.6"]' ||
+          '["2.0.6"]') }}
         machine:
         - V1CNC_Archim1
         - V1CNC_Archim1_Dual

--- a/.github/workflows/rambo.yml
+++ b/.github/workflows/rambo.yml
@@ -32,9 +32,10 @@ jobs:
     strategy:
       fail-fast: false # Allow all machines to finish building
       matrix:
-        branch:
-        - 2.0.6
-        - bugfix-2.0.x
+        branch: ${{ fromJson(
+          github.event_name == 'schedule' && '["bugfix-2.0.x"]' ||
+          github.event_name == 'pull_request' && '["bugfix-2.0.x", "2.0.6"]' ||
+          '["2.0.6"]') }}
         machine:
         - V13DP_MiniRambo
         - V1CNC_MiniRambo

--- a/.github/workflows/ramps.yml
+++ b/.github/workflows/ramps.yml
@@ -32,9 +32,10 @@ jobs:
     strategy:
       fail-fast: false # Allow all machines to finish building
       matrix:
-        branch:
-        - 2.0.6
-        - bugfix-2.0.x
+        branch: ${{ fromJson(
+          github.event_name == 'schedule' && '["bugfix-2.0.x"]' ||
+          github.event_name == 'pull_request' && '["bugfix-2.0.x", "2.0.6"]' ||
+          '["2.0.6"]') }}
         machine:
         - V13DP_Ramps_MK8
         - V1ZXY_Ramps

--- a/.github/workflows/skr1p3.yml
+++ b/.github/workflows/skr1p3.yml
@@ -33,9 +33,10 @@ jobs:
     strategy:
       fail-fast: false # Allow all machines to finish building
       matrix:
-        branch:
-        - 2.0.6
-        - bugfix-2.0.x
+        branch: ${{ fromJson(
+          github.event_name == 'schedule' && '["bugfix-2.0.x"]' ||
+          github.event_name == 'pull_request' && '["bugfix-2.0.x", "2.0.6"]' ||
+          '["2.0.6"]') }}
         machine:
         - V1CNC_Skr1p3_8825
         - V1CNC_Skr1p3_2209

--- a/.github/workflows/skrpro.yml
+++ b/.github/workflows/skrpro.yml
@@ -33,9 +33,10 @@ jobs:
     strategy:
       fail-fast: false # Allow all machines to finish building
       matrix:
-        branch:
-        - 2.0.6
-        - bugfix-2.0.x
+        branch: ${{ fromJson(
+          github.event_name == 'schedule' && '["bugfix-2.0.x"]' ||
+          github.event_name == 'pull_request' && '["bugfix-2.0.x", "2.0.6"]' ||
+          '["2.0.6"]') }}
         machine:
         - V1CNC_SkrPro_2209
         - V1CNC_SkrPro_DualLR_2209


### PR DESCRIPTION
This should serve as stop-gap until workflow composition becomes possible

Note: If we were only building a single branch for PRs, it would be a lot simpler

```
- ${{ github.event_name == 'schedule' && 'bugfix-2.0.x' || '2.0.6' }}
```